### PR TITLE
feat: Implement esbuild bundling for workers-site worker\n\n- Added e…

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"@vitest/coverage-v8": "^3.2.4",
 		"c8": "^10.1.3",
 		"globals": "^16.3.0",
-		"vitest": "~3.2.0"
+		"vitest": "~3.2.0",
+		"esbuild": "^0.25.8"
 	},
 	"dependencies": {
 		"chalk": "^5.4.1",

--- a/web-ui/workers-site/package.json
+++ b/web-ui/workers-site/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "workers-site",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "build": "esbuild index.js --bundle --outfile=dist/index.js --minify",
+    "deploy": "npm run build && wrangler deploy"
+  },
+  "dependencies": {
+    "@cloudflare/kv-asset-handler": "^0.3.0"
+  }
+}


### PR DESCRIPTION
…sbuild as a dev dependency to the root package.json.\n- Configured web-ui/workers-site/package.json to use esbuild for bundling:\n  - Added a 'build' script to bundle index.js into dist/index.js.\n  - Modified the 'deploy' script to run the 'build' script before deployment.\n- This change addresses the deployment error related to @cloudflare/kv-asset-handler not being found.