### PR TITLE
feat: Migrate web-ui to Cloudflare Workers static assets

### DIFF
--- a/web-ui/workers-site/index.js
+++ b/web-ui/workers-site/index.js
@@ -1,20 +1,22 @@
-import { getAssetFromKV } from '@cloudflare/kv-asset-handler';
-
-addEventListener('fetch', (event) => {
-  event.respondWith(handleEvent(event));
-});
-
-async function handleEvent(event) {
-  try {
-    return await getAssetFromKV(event);
-  } catch (e) {
-    // If the asset is not found, serve the main index.html for single-page apps.
+export default {
+  async fetch(request, env, ctx) {
     try {
-      return await getAssetFromKV(event, {
-        mapRequestToAsset: (req) => new Request(`${new URL(req.url).origin}/index.html`, req),
-      });
+      // Try to serve the static asset using the ASSETS binding.
+      // The ASSETS binding is automatically provided by Cloudflare Workers
+      // when you configure [assets] in wrangler.toml.
+      return await env.ASSETS.fetch(request);
     } catch (e) {
-      return new Response('Not found', { status: 404 });
+      // If the asset is not found, serve the main index.html for single-page apps.
+      // This is a common pattern for SPAs where all routes should fall back to index.html.
+      try {
+        const url = new URL(request.url);
+        // Construct a new request to index.html.
+        const indexRequest = new Request(`${url.origin}/index.html`, request);
+        return await env.ASSETS.fetch(indexRequest);
+      } catch (e) {
+        // If even index.html is not found, return a 404.
+        return new Response('Not found', { status: 404 });
+      }
     }
-  }
-}
+  },
+};

--- a/web-ui/wrangler.toml
+++ b/web-ui/wrangler.toml
@@ -2,5 +2,13 @@ name = "snapurl-web-ui"
 main = "workers-site/index.js"
 compatibility_date = "2024-01-01"
 
-[site]
-bucket = "./client/dist"
+#[site]
+#bucket = "./client/dist"
+
+[observability]
+enabled = true
+head_sampling_rate = 1 # optional. default = 1.
+
+[assets]
+directory = "./client/dist"
+binding = "ASSETS"


### PR DESCRIPTION
Migrates the web-ui worker from using `@cloudflare/kv-asset-handler` to the built-in Cloudflare Workers static assets feature.

- Updates `web-ui/wrangler.toml` to use the `[assets]` configuration, binding the `./client/dist` directory to the `ASSETS` environment variable.
- Refactors `web-ui/workers-site/index.js` to use `env.ASSETS.fetch()` for serving static content and implements SPA fallback logic.